### PR TITLE
Add greengrass resource

### DIFF
--- a/aws/resource_aws_greengrass_resource_definition_test.go
+++ b/aws/resource_aws_greengrass_resource_definition_test.go
@@ -203,21 +203,19 @@ func testAccAWSGreengrassResourceDefinitionConfig_LocalDevice(rString string) st
 	return fmt.Sprintf(`
 resource "aws_greengrass_resource_definition" "test" {
 	name = "resource_definition_%[1]s"
-	resource_definition_version {
-		resource {
-			id = "test_id"
-			name = "test_name"
-			data_container {
-				local_device_resource_data {
-					source_path = "/dev/source"
+    resource {
+        id = "test_id"
+        name = "test_name"
+        data_container {
+            local_device_resource_data {
+                source_path = "/dev/source"
 
-					group_owner_setting {
-						auto_add_group_owner = false
-						group_owner = "user"
-					}
-				}
-			}
-		}
+                group_owner_setting {
+                    auto_add_group_owner = false
+                    group_owner = "user"
+                }
+            }
+        }
 	}
 }
 `, rString)
@@ -227,23 +225,21 @@ func testAccAWSGreengrassResourceDefinitionConfig_LocalVolume(rString string) st
 	return fmt.Sprintf(`
 resource "aws_greengrass_resource_definition" "test" {
 	name = "resource_definition_%[1]s"
-	resource_definition_version {
-		resource {
-			id = "test_id"
-			name = "test_name"
-			data_container {
+    resource {
+        id = "test_id"
+        name = "test_name"
+        data_container {
 
-				local_volume_resource_data {
-					source_path = "/dev/source"
-					destination_path = "/destination"
+            local_volume_resource_data {
+                source_path = "/dev/source"
+                destination_path = "/destination"
 
-					group_owner_setting {
-						auto_add_group_owner = false
-						group_owner = "user"
-					}
-				}
-			}
-		}
+                group_owner_setting {
+                    auto_add_group_owner = false
+                    group_owner = "user"
+                }
+            }
+        }
 	}
 }
 `, rString)
@@ -253,17 +249,15 @@ func testAccAWSGreengrassResourceDefinitionConfig_S3MachineLearningModel(rString
 	return fmt.Sprintf(`
 resource "aws_greengrass_resource_definition" "test" {
 	name = "resource_definition_%[1]s"
-	resource_definition_version {
-		resource {
-			id = "test_id"
-			name = "test_name"
-			data_container {
-				s3_machine_learning_model_resource_data {
-					s3_uri = "s3://bucket/key.zip"
-					destination_path = "/destination"
-				}
-			}
-		}
+    resource {
+        id = "test_id"
+        name = "test_name"
+        data_container {
+            s3_machine_learning_model_resource_data {
+                s3_uri = "s3://bucket/key.zip"
+                destination_path = "/destination"
+            }
+        }
 	}
 }
 `, rString)
@@ -275,18 +269,16 @@ data "aws_caller_identity" "current" {}
 
 resource "aws_greengrass_resource_definition" "test" {
 	name = "resource_definition_%[1]s"
-	resource_definition_version {
-		resource {
-			id = "test_id"
-			name = "test_name"
-			data_container {
-				sagemaker_machine_learning_model_resource_data {
-					sagemaker_job_arn = "arn:aws:sagemaker:us-west-2:${data.aws_caller_identity.current.account_id}:training-job/xgboost-2018-06-05-17-19-32-703"
-					destination_path = "/destination"
-				}
-			}
-		}
-	}
+    resource {
+        id = "test_id"
+        name = "test_name"
+        data_container {
+            sagemaker_machine_learning_model_resource_data {
+                sagemaker_job_arn = "arn:aws:sagemaker:us-west-2:${data.aws_caller_identity.current.account_id}:training-job/xgboost-2018-06-05-17-19-32-703"
+                destination_path = "/destination"
+            }
+        }
+    }
 }
 `, rString)
 }
@@ -295,20 +287,18 @@ func testAccAWSGreengrassResourceDefinitionConfig_SecretsManagerSecret(rString s
 	return fmt.Sprintf(`
 resource "aws_greengrass_resource_definition" "test" {
 	name = "resource_definition_%[1]s"
-	resource_definition_version {
-		resource {
-			id = "test_id"
-			name = "test_name"
-			data_container {
-				secrets_manager_secret_resource_data {
-					secret_arn = "arn:aws:secretsmanager:us-west-2:123456789012:secret:greengrass-TwilioAuthToken-ntSlp6"
-					additional_staging_labels_to_download = [
-						"label1",
-						"label2",
-					]
-				}
-			}
-		}
+    resource {
+        id = "test_id"
+        name = "test_name"
+        data_container {
+            secrets_manager_secret_resource_data {
+                secret_arn = "arn:aws:secretsmanager:us-west-2:123456789012:secret:greengrass-TwilioAuthToken-ntSlp6"
+                additional_staging_labels_to_download = [
+                    "label1",
+                    "label2",
+                ]
+            }
+        }
 	}
 }
 `, rString)

--- a/website/docs/r/greengrass_resource_definition.html.markdown
+++ b/website/docs/r/greengrass_resource_definition.html.markdown
@@ -13,21 +13,19 @@ description: |-
 ```hcl
 resource "aws_greengrass_resource_definition" "test" {
 	name = "resource_definition"
-	resource_definition_version {
-		resource {
-			id = "test_id"
-			name = "test_name"
-			data_container {
-				local_device_resource_data {
-					source_path = "/dev/source"
+    resource {
+        id = "test_id"
+        name = "test_name"
+        data_container {
+            local_device_resource_data {
+                source_path = "/dev/source"
 
-					group_owner_setting {
-						auto_add_group_owner = false
-						group_owner = "user"
-					}
-				}
-			}
-		}
+                group_owner_setting {
+                    auto_add_group_owner = false
+                    group_owner = "user"
+                }
+            }
+        }
 	}
 }
 ```
@@ -35,10 +33,7 @@ resource "aws_greengrass_resource_definition" "test" {
 ## Argument Reference
 * `name` - (Required) The name of the resource definition.
 * `tags` - (Optional) Map. Map of tags. Metadata that can be used to manage the resource definition.
-* `resource_definition_version` - (Optional) Object. Information about a resource definition version.
-
-The `resource_definition_version` object has such arguments.
-* `resource` - (Optional) List. Component of resource definition.
+* `resource` - (Optional) Object. Information about a resource definition.
 
 The `resource` object has such arguments:
 * `id` - (Required) String. The resource ID, used to refer to a resource in the Lambda function configuration. Max length is 128 characters with pattern ''[a-zA-Z0-9:_-]+''. This must be unique within a Greengrass group.


### PR DESCRIPTION
Added reviewer changes as requested in https://github.com/terraform-providers/terraform-provider-aws/pull/10881. Removed redundant field `resource_definition_version`, and added resource version acceptance tests.

```
make testacc TEST=./aws TESTARGS='-run=TestAccAWSGreengrassResourceDefinition_'                                                                             ==> Checking that code complies with gofmt requirements...                                          
TF_ACC=1 go test ./aws -v -count 1 -parallel 20 -run=TestAccAWSGreengrassResourceDefinition_ -timeout 120m
=== RUN   TestAccAWSGreengrassResourceDefinition_basic
=== PAUSE TestAccAWSGreengrassResourceDefinition_basic
=== RUN   TestAccAWSGreengrassResourceDefinition_versionNoop
=== PAUSE TestAccAWSGreengrassResourceDefinition_versionNoop
=== RUN   TestAccAWSGreengrassResourceDefinition_versionDiff
=== PAUSE TestAccAWSGreengrassResourceDefinition_versionDiff
=== RUN   TestAccAWSGreengrassResourceDefinition_LocalDevice
=== PAUSE TestAccAWSGreengrassResourceDefinition_LocalDevice
=== RUN   TestAccAWSGreengrassResourceDefinition_LocalVolume
=== PAUSE TestAccAWSGreengrassResourceDefinition_LocalVolume
=== RUN   TestAccAWSGreengrassResourceDefinition_S3MachineLearningModel
=== PAUSE TestAccAWSGreengrassResourceDefinition_S3MachineLearningModel
=== RUN   TestAccAWSGreengrassResourceDefinition_SagemakerMachineLearningModel
=== PAUSE TestAccAWSGreengrassResourceDefinition_SagemakerMachineLearningModel
=== RUN   TestAccAWSGreengrassResourceDefinition_SecretsManagerSecret
=== PAUSE TestAccAWSGreengrassResourceDefinition_SecretsManagerSecret
=== CONT  TestAccAWSGreengrassResourceDefinition_basic
=== CONT  TestAccAWSGreengrassResourceDefinition_S3MachineLearningModel
=== CONT  TestAccAWSGreengrassResourceDefinition_SecretsManagerSecret
=== CONT  TestAccAWSGreengrassResourceDefinition_SagemakerMachineLearningModel
=== CONT  TestAccAWSGreengrassResourceDefinition_LocalDevice
=== CONT  TestAccAWSGreengrassResourceDefinition_LocalVolume
=== CONT  TestAccAWSGreengrassResourceDefinition_versionDiff
=== CONT  TestAccAWSGreengrassResourceDefinition_versionNoop
--- PASS: TestAccAWSGreengrassResourceDefinition_basic (53.08s)
--- PASS: TestAccAWSGreengrassResourceDefinition_SecretsManagerSecret (54.53s)
--- PASS: TestAccAWSGreengrassResourceDefinition_S3MachineLearningModel (54.71s)
--- PASS: TestAccAWSGreengrassResourceDefinition_LocalDevice (54.71s)
--- PASS: TestAccAWSGreengrassResourceDefinition_LocalVolume (55.28s)
--- PASS: TestAccAWSGreengrassResourceDefinition_SagemakerMachineLearningModel (58.04s)
--- PASS: TestAccAWSGreengrassResourceDefinition_versionNoop (86.42s)
--- PASS: TestAccAWSGreengrassResourceDefinition_versionDiff (86.64s)
PASS
ok  	github.com/terraform-providers/terraform-provider-aws/aws	86.688s
```
